### PR TITLE
Corrected a response status code

### DIFF
--- a/2016-01-06/swagger/bucket_cors.json
+++ b/2016-01-06/swagger/bucket_cors.json
@@ -84,7 +84,7 @@
       "url": "https://docs.qingcloud.com/qingstor/api/bucket/cors/delete_cors.html"
     },
     "responses": {
-      "200": {
+      "204": {
         "description": "OK"
       }
     }


### PR DESCRIPTION
Corrected the response status code of operation `DeleteBucketCORS`.
According to QingStor documents, it should be `204` for OK

Signed-off-by: XieQirong <cheerx1994@163.com>