### PR TITLE
add API to upload metadata when putobject.

### DIFF
--- a/2016-01-06/swagger/object.json
+++ b/2016-01-06/swagger/object.json
@@ -157,6 +157,12 @@
         ]
       },
       {
+        "name": "X-QS-MetaData",
+        "description": "User-defined metadata",
+        "type": "map[string]string",
+        "in": "header"
+      },
+      {
         "name": "Body",
         "description": "The request body",
         "in": "body",

--- a/2016-01-06/swagger/object.json
+++ b/2016-01-06/swagger/object.json
@@ -159,7 +159,7 @@
       {
         "name": "X-QS-MetaData",
         "description": "User-defined metadata",
-        "type": "map[string]string",
+        "type": "map",
         "in": "header"
       },
       {

--- a/api_spec_schema_swagger_v2.0.json
+++ b/api_spec_schema_swagger_v2.0.json
@@ -568,7 +568,7 @@
             "boolean",
             "integer",
             "array",
-            "map[string]string"
+            "map"
           ]
         },
         "format": {

--- a/api_spec_schema_swagger_v2.0.json
+++ b/api_spec_schema_swagger_v2.0.json
@@ -567,7 +567,8 @@
             "number",
             "boolean",
             "integer",
-            "array"
+            "array",
+            "map[string]string"
           ]
         },
         "format": {


### PR DESCRIPTION
By this change, we can use snips and template to generate `PutObjectInput` that includes `XQSMetaData` in `qingstor-sdk-go/service/object.go`, it helps users to add metadata when they  putting object by sdk.

 Signed-off-by: Ubique0305 <1071763478@qq.com>